### PR TITLE
Require minimum of WordPress 5.2

### DIFF
--- a/domain/AutomatedUpcomingEventNotifications.php
+++ b/domain/AutomatedUpcomingEventNotifications.php
@@ -81,6 +81,7 @@ class AutomatedUpcomingEventNotifications extends EE_Addon
                 'version'          => $domain->version(),
                 'plugin_slug'      => 'eea_automated_upcoming_event_notifications',
                 'min_core_version' => Domain::CORE_VERSION_REQUIRED,
+                'min_wp_version'   => Domain::WP_VERSION_REQUIRED,
                 'main_file_path'   => $domain->pluginFile(),
                 'domain_fqcn'      => Domain::class,
                 'pue_options'      => array(

--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -22,6 +22,12 @@ class Domain extends DomainBase
 
 
     /**
+     * WordPress Version Required for Add-on
+     */
+    const WP_VERSION_REQUIRED = '5.2';
+
+
+    /**
      * String used as the prefix for the registration tracker meta key for the RegistrationsNotifiedCommand
      */
     const META_KEY_PREFIX_REGISTRATION_TRACKER = 'ee_auen_processed_';

--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -18,7 +18,7 @@ class Domain extends DomainBase
     /**
      * EE Core Version Required for Add-on
      */
-    const CORE_VERSION_REQUIRED = '4.9.54.rc.007';
+    const CORE_VERSION_REQUIRED = '4.9.81.p';
 
 
     /**


### PR DESCRIPTION
Ideally this add-on should require WordPress 5.2 because the built in Site Health tools will be most helpful for debugging when sites do not have wp_cron set up.

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models) 