### PR TITLE
Remove Google plus and update social link markup; Resolves #11

### DIFF
--- a/views/message/templates/email_automate_upcoming_datetime_content.template.php
+++ b/views/message/templates/email_automate_upcoming_datetime_content.template.php
@@ -71,15 +71,8 @@
                             <tr>
                                 <td>
                                     <h5><?php esc_html_e('Connect with Us:', 'event_espresso'); ?></h5>
-                                    <a class="soc-btn fb" href="[CO_FACEBOOK_URL]">
-                                        <?php esc_html_e('Facebook', 'event_espresso'); ?>
-                                    </a>
-                                    <a class="soc-btn tw" href="[CO_TWITTER_URL]">
-                                        <?php esc_html_e('Twitter', 'event_espresso'); ?>
-                                    </a>
-                                    <a class="soc-btn gp" href="[CO_GOOGLE_URL]">
-                                        <?php esc_html_e('Google+', 'event_espresso'); ?>
-                                    </a>
+                                    <a class="soc-btn fb" href="[CO_FACEBOOK_URL]"><?php esc_html_e('Facebook', 'event_espresso'); ?></a>
+                                    <a class="soc-btn tw" href="[CO_TWITTER_URL]"><?php esc_html_e('Twitter', 'event_espresso'); ?></a>
                                 </td>
                             </tr>
                             </tbody>

--- a/views/message/templates/email_automate_upcoming_event_content.template.php
+++ b/views/message/templates/email_automate_upcoming_event_content.template.php
@@ -68,15 +68,8 @@
                             <tr>
                                 <td>
                                     <h5><?php esc_html_e('Connect with Us:', 'event_espresso'); ?></h5>
-                                    <a class="soc-btn fb" href="[CO_FACEBOOK_URL]">
-                                        <?php esc_html_e('Facebook', 'event_espresso'); ?>
-                                    </a>
-                                    <a class="soc-btn tw" href="[CO_TWITTER_URL]">
-                                        <?php esc_html_e('Twitter', 'event_espresso'); ?>
-                                    </a>
-                                    <a class="soc-btn gp" href="[CO_GOOGLE_URL]">
-                                        <?php esc_html_e('Google+', 'event_espresso'); ?>
-                                    </a>
+                                    <a class="soc-btn fb" href="[CO_FACEBOOK_URL]"><?php esc_html_e('Facebook', 'event_espresso'); ?></a>
+                                    <a class="soc-btn tw" href="[CO_TWITTER_URL]"><?php esc_html_e('Twitter', 'event_espresso'); ?></a>
                                 </td>
                             </tr>
                             </tbody>


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #11 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Reset both AUEN templates (both the Event and Datetime templates). Then check the message preview. The Google + links should not be included in the reset templates. Also, the extra spacing within the display should also be removed with this branch (after template is reset).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
