### PR TITLE
Change getStartTimeForQuery so it longer adds a day onto current time

### DIFF
--- a/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
@@ -276,19 +276,13 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
 
     /**
      * The threshold for upcoming notifications is currently in intervals of days.  This means that the accuracy of the
-     * time will be down to the day (not the hour or the minute).  Since our scheduled cron fires daily at midnight, if
-     * the threshold is set to one day before the day of the event, then anything between 00:00 and 23:59 of the day
-     * the cron fired is NOT one day before the event but UNDER one day.  So for accuracy at this interval, the start
-     * time for the query should be one day from the time the cron job is triggered. This means then that if the
-     * threshold is set to one day, and the time the scheduled cron fires is September 21, 00:00:00, we want to query
-     * for start datetimes between September 22, 00:00:00 and September 22, 23:59:59 (we'll actually do the query for to
-     * include that last minute so `September 23, 00:00:00 for simplicity).
+     * time will be down to the day (not the hour or the minute).
      *
      * @return int
      */
     protected function getStartTimeForQuery()
     {
-        return time() + DAY_IN_SECONDS;
+        return time();
     }
 
 


### PR DESCRIPTION
The crons for this add-on originally ran once a day, so the current time for the query needed to take that into account and add a day onto the start date/time used, as they now run every 3 hours this extra day is basically running the query 1 day head of when it should be.

This change uses just the current time + the 'interval'.

So messages triggered 1 day before the event use:
start_date BETWEEN now AND now + {1 day} + {cron buffer}

----

To test, set up an event with a reminder set to go out 1 day before the event.

With master branch, the reminder would actually trigger 2 days before the event.

With this branch is should be close to 1 day.

One way to test this is to set up the event and then nudge the DateTime start date back a little to its within a day of 'now' and manually run the cron, to confirm it only triggers the notifications when the start date is roughly now + 3 hours.

This add-on adds extra meta to the event to show if it has already been notified so once you've triggered notifications for an event you'll need to remove any meta keys prefixed with `ee_auen_processed_` for that event to trigger them again if needed.

(Both reminders for events and datetimes use this same query so it should fix both, test both template types)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
