### PR TITLE
Bug/dont require updating old events

### DIFF
--- a/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
@@ -334,8 +334,7 @@ class UpcomingDatetimeNotificationsCommandHandler extends UpcomingNotificationsC
      * datetimes that have been notified and this conditional will be used in the initial query for getting datetimes.
      *
      * @param string $context The context we're getting the notified registrations for.
-     * @return array The array should be in the format used for EE model where conditions.  Eg.
-     *                        array('EVT_ID' => array( 'NOT IN', array(1,2,3))
+     * @return array The array should be numeric and contain datetime ID's that have already been notified.
      * @throws EE_Error
      */
     protected function itemsToExclude($context)

--- a/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
@@ -267,7 +267,7 @@ class UpcomingDatetimeNotificationsCommandHandler extends UpcomingNotificationsC
           LEFT JOIN (
             SELECT emt.GRP_ID, emt.EVT_ID, mtp.MTP_deleted FROM 
             {$wpdb->prefix}esp_event_message_template AS emt
-            LEFT JOIN {$wpdb->prefix}esp_message_template_group mtp ON emt.GRP_ID = mtp.GRP_ID AND mtp.MTP_message_type = 'automate_upcoming_datetime'
+            INNER JOIN {$wpdb->prefix}esp_message_template_group mtp ON emt.GRP_ID = mtp.GRP_ID AND mtp.MTP_message_type = 'automate_upcoming_datetime'
             ) AS emt_mtp ON Event_CPT.ID = emt_mtp.EVT_ID  
           WHERE 
           Datetime.DTT_deleted = 0 

--- a/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
@@ -161,11 +161,13 @@ class UpcomingDatetimeNotificationsCommandHandler extends UpcomingNotificationsC
 
         // extract the ids of the datetimes already in the data so we exclude them from the global message template group
         // based query.
-        $datetimes_to_exclude = $this->getDateTimeIdsFromData($data, $context);
+        $datetime_ids_from_data = $this->getDateTimeIdsFromData($data, $context);
+        // combine the datetimes from data with the items we already know we want to exclude.
+        $items_to_exclude = array_merge($items_to_exclude, $datetime_ids_from_data);
         return $this->getRegistrationsForDatetimeAndMessageTemplateGroupAndContext(
             $scheduling_settings,
             $context,
-            $datetimes_to_exclude
+            $items_to_exclude
         );
     }
 

--- a/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingDatetimeNotificationsCommandHandler.php
@@ -254,7 +254,9 @@ class UpcomingDatetimeNotificationsCommandHandler extends UpcomingNotificationsC
         array $datetimes_to_exclude = array()
     ) {
         global $wpdb;
-        $event_statuses_sql = implode(',', array_map(function($input){return "'$input'";},$this->eventStatusForRegistrationsQuery()));
+        $event_statuses_sql = implode(',', array_map(function ($input) {
+            return "'$input'";
+        }, $this->eventStatusForRegistrationsQuery()));
         $query_with_placeholders = "
         SELECT 
           Datetime.DTT_ID  

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -273,8 +273,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
      * where query that will then be used in the eventual registrations query.
      *
      * @param string $context The context we're getting the notified registrations for.
-     * @return array The array should be in the format used for EE model where conditions.  Eg.
-     *                        array('EVT_ID' => array( 'NOT IN', array(1,2,3))
+     * @return array The array should be numeric and contain event ID's that have already been notified. 
      * @throws EE_Error
      */
     protected function itemsToExclude($context)

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -138,7 +138,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
     /**
      * @param SchedulingSettings $settings
      * @param string             $context
-     * @param array              $registrations_to_exclude of registration IDs
+     * @param array              $events_to_exclude of registration IDs
      * @return EE_Base_Class[]|EE_Registration[]
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -149,7 +149,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
     protected function getRegistrationsForMessageTemplateGroup(
         SchedulingSettings $settings,
         $context,
-        array $registrations_to_exclude = array()
+        array $events_to_exclude = array()
     ) {
         global $wpdb;
         // Use good-old wpdb directly here, because we need to do a sub-query to join the event-message-template table
@@ -189,8 +189,8 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
             $query_with_placeholders .= ' OR emt_mtp.GRP_ID IS NULL';
         }
         $query_with_placeholders .= ')';
-        if ($registrations_to_exclude) {
-            $query_with_placeholders .= ' AND Registration.REG_ID NOT IN (' . implode(',', $registrations_to_exclude) . ')';
+        if ($events_to_exclude) {
+            $query_with_placeholders .= ' AND Event_CPT.ID NOT IN (' . implode(',', $events_to_exclude) . ')';
         }
         $query_with_placeholders .= " GROUP BY Registration.REG_ID";
         $query = $wpdb->prepare(

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -284,7 +284,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
             'Datetime.DTT_EVT_start' => array('>', time()),
             'Extra_Meta.EXM_key'     => $meta_key,
         );
-        return (array)$this->event_model->get_col(array($where));
+        return (array) $this->event_model->get_col(array($where));
     }
 
 

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -152,8 +152,11 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
         array $registrations_to_exclude = array()
     ) {
         global $wpdb;
-        // Use good-old wpdb directly here, because we need to add a condition onto a JOIN (not just a where condition
-        // later).
+        // Use good-old wpdb directly here, because we need to do a sub-query to join the event-message-template table
+        // with the message-template-group table first, using the message type as a joining condition, and afterwards
+        // join to it from the other tables. This way query for registrations using the global template will include
+        // registrations for events with no upcoming event notification template; but not registrations for events using
+        // a custom upcoming event notification template.
         // See https://github.com/eventespresso/eea-automated-upcoming-event-notifications/issues/14#issuecomment-550464526
         $query_with_placeholders = "
         SELECT 
@@ -166,21 +169,24 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
           LEFT JOIN {$wpdb->prefix}posts AS Event_CPT ON Event_CPT.ID=Registration.EVT_ID 
           LEFT JOIN {$wpdb->prefix}esp_event_meta AS Event_Meta ON Event_CPT.ID = Event_Meta.EVT_ID  
           LEFT JOIN {$wpdb->prefix}esp_datetime AS Event___Datetime ON Event___Datetime.EVT_ID=Event_CPT.ID 
-          LEFT JOIN {$wpdb->prefix}esp_event_message_template AS Event___Event_Message_Template ON Event___Event_Message_Template.EVT_ID=Event_CPT.ID
-          LEFT JOIN {$wpdb->prefix}esp_message_template_group AS Event___Message_Template_Group ON Event___Message_Template_Group.GRP_ID=Event___Event_Message_Template.GRP_ID AND Event___Message_Template_Group.MTP_message_type='automate_upcoming_event'
+          LEFT JOIN (
+            SELECT emt.GRP_ID, emt.EVT_ID, mtp.MTP_deleted FROM 
+            {$wpdb->prefix}esp_event_message_template AS emt
+            LEFT JOIN {$wpdb->prefix}esp_message_template_group mtp ON emt.GRP_ID = mtp.GRP_ID AND mtp.MTP_message_type = 'automate_upcoming_event'
+            ) AS emt_mtp ON Event_CPT.ID = emt_mtp.EVT_ID 
         WHERE 
           Registration.REG_deleted = 0  
           AND (Event_CPT.post_type = 'espresso_events')  
           AND ( (Event___Datetime.DTT_deleted = 0) OR Event___Datetime.DTT_ID IS NULL)  
-          AND ( (Event___Message_Template_Group.MTP_deleted = 0) OR Event___Message_Template_Group.GRP_ID IS NULL) 
+          AND ( (emt_mtp.MTP_deleted = 0) OR emt_mtp.GRP_ID IS NULL) 
           AND Event_CPT.post_status IN ('publish','sold_out') 
           AND Event___Datetime.DTT_EVT_start BETWEEN %s AND %s
           AND Registration.STS_ID = 'RAP'
-          AND (Event___Event_Message_Template.GRP_ID=%d
+          AND (emt_mtp.GRP_ID=%d
         ";
         // If it's a global template, select registrations for events with no message template.
         if ($settings->getMessageTemplateGroup()->is_global()) {
-            $query_with_placeholders .= ' OR Event___Message_Template_Group.GRP_ID IS NULL';
+            $query_with_placeholders .= ' OR emt_mtp.GRP_ID IS NULL';
         }
         $query_with_placeholders .= ')';
         if ($registrations_to_exclude) {

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -273,7 +273,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
      * where query that will then be used in the eventual registrations query.
      *
      * @param string $context The context we're getting the notified registrations for.
-     * @return array The array should be numeric and contain event ID's that have already been notified. 
+     * @return array The array should be numeric and contain event ID's that have already been notified.
      * @throws EE_Error
      */
     protected function itemsToExclude($context)

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -172,7 +172,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
           LEFT JOIN (
             SELECT emt.GRP_ID, emt.EVT_ID, mtp.MTP_deleted FROM 
             {$wpdb->prefix}esp_event_message_template AS emt
-            LEFT JOIN {$wpdb->prefix}esp_message_template_group mtp ON emt.GRP_ID = mtp.GRP_ID AND mtp.MTP_message_type = 'automate_upcoming_event'
+            INNER JOIN {$wpdb->prefix}esp_message_template_group mtp ON emt.GRP_ID = mtp.GRP_ID AND mtp.MTP_message_type = 'automate_upcoming_event'
             ) AS emt_mtp ON Event_CPT.ID = emt_mtp.EVT_ID 
         WHERE 
           Registration.REG_deleted = 0  

--- a/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingEventNotificationsCommandHandler.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\AutomatedUpcomingEventNotifications\domain\services\commands\message;
 
+use EE_Datetime_Field;
 use EEM_Event;
 use EventEspresso\AutomatedUpcomingEventNotifications\domain\entities\message\SchedulingSettings;
 use EEM_Registration;
@@ -137,7 +138,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
     /**
      * @param SchedulingSettings $settings
      * @param string             $context
-     * @param array              $additional_where_parameters
+     * @param array              $registrations_to_exclude of registration IDs
      * @return EE_Base_Class[]|EE_Registration[]
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -148,43 +149,50 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
     protected function getRegistrationsForMessageTemplateGroup(
         SchedulingSettings $settings,
         $context,
-        array $additional_where_parameters = array()
+        array $registrations_to_exclude = array()
     ) {
-        $where = array(
-            'Event.status'                 => array('IN', $this->eventStatusForRegistrationsQuery()),
-            'Event.Datetime.DTT_EVT_start' => array(
-                'BETWEEN',
-                array(
-                    $this->getStartTimeForQuery(),
-                    $this->getEndTimeForQuery($settings, $context),
-                ),
-            ),
-            'STS_ID'                       => EEM_Registration::status_id_approved,
-            'REG_deleted'                  => 0,
-        );
-
-        if ($additional_where_parameters) {
-            $where = array_merge($where, $additional_where_parameters);
-        }
+        global $wpdb;
+        // Use good-old wpdb directly here, because we need to add a condition onto a JOIN (not just a where condition
+        // later).
+        // See https://github.com/eventespresso/eea-automated-upcoming-event-notifications/issues/14#issuecomment-550464526
+        $query_with_placeholders = "
+        SELECT 
+          REG_ID AS REG_ID, 
+          ATT_ID AS ATT_ID, 
+          Registration.EVT_ID AS EVT_ID, 
+          Registration.TXN_ID AS TXN_ID  
+        FROM  
+          {$wpdb->prefix}esp_registration AS Registration 
+          LEFT JOIN {$wpdb->prefix}posts AS Event_CPT ON Event_CPT.ID=Registration.EVT_ID 
+          LEFT JOIN {$wpdb->prefix}esp_event_meta AS Event_Meta ON Event_CPT.ID = Event_Meta.EVT_ID  
+          LEFT JOIN {$wpdb->prefix}esp_datetime AS Event___Datetime ON Event___Datetime.EVT_ID=Event_CPT.ID 
+          LEFT JOIN {$wpdb->prefix}esp_event_message_template AS Event___Event_Message_Template ON Event___Event_Message_Template.EVT_ID=Event_CPT.ID AND Event___Event_Message_Template.GRP_ID=%d
+          LEFT JOIN {$wpdb->prefix}esp_message_template_group AS Event___Message_Template_Group ON Event___Message_Template_Group.GRP_ID=Event___Event_Message_Template.GRP_ID
+        WHERE 
+          Registration.REG_deleted = 0 AND  
+          (Event_CPT.post_type = 'espresso_events') AND  
+          ( (Event___Datetime.DTT_deleted = 0) OR Event___Datetime.DTT_ID IS NULL) AND  
+          ( (Event___Message_Template_Group.MTP_deleted = 0) OR Event___Message_Template_Group.GRP_ID IS NULL) AND 
+          Event_CPT.post_status IN ('publish','sold_out') AND 
+          Event___Datetime.DTT_EVT_start BETWEEN %s AND %s AND 
+          Registration.STS_ID = 'RAP' AND
+        ";
         if ($settings->getMessageTemplateGroup()->is_global()) {
-            $where['OR*global_conditions'] = array(
-                'Event.Message_Template_Group.GRP_ID'      => $settings->getMessageTemplateGroup()->ID(),
-                'Event.Message_Template_Group.GRP_ID*null' => array('IS NULL'),
-            );
-        } else {
-            $where['Event.Message_Template_Group.GRP_ID'] = $settings->getMessageTemplateGroup()->ID();
+            $query_with_placeholders .= ' Event___Message_Template_Group.GRP_ID IS NULL';
         }
+        if ($registrations_to_exclude) {
+            $query_with_placeholders .= ' AND Registration.REG_ID NOT IN (' . implode(',', $registrations_to_exclude) . ')';
+        }
+
+        $query_with_placeholders .= " GROUP BY Registration.REG_ID";
+        $query = $wpdb->prepare(
+            $query_with_placeholders,
+            $settings->getMessageTemplateGroup()->ID(),
+            date(EE_Datetime_Field::mysql_timestamp_format, $this->getStartTimeForQuery()),
+            date(EE_Datetime_Field::mysql_timestamp_format, $this->getEndTimeForQuery($settings, $context))
+        );
         return $this->setKeysToRegistrationIds(
-            $this->registration_model->get_all_wpdb_results(
-                array($where, 'group_by' => 'REG_ID'),
-                ARRAY_A,
-                array(
-                    'REG_ID' => array('REG_ID', '%d'),
-                    'ATT_ID' => array('ATT_ID', '%d'),
-                    'EVT_ID' => array('Registration.EVT_ID', '%d'),
-                    'TXN_ID' => array('Registration.TXN_ID', '%d'),
-                )
-            )
+            $wpdb->get_results($query, ARRAY_A)
         );
     }
 
@@ -195,7 +203,7 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
      * @param EE_Message_Template_Group[]|SchedulingSettings $scheduling_settings
      * @param string                                         $context
      * @param array                                          $data
-     * @param array                                          $registrations_to_exclude_where_query
+     * @param array                                          $registrations_to_exclude
      * @return array
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -207,28 +215,15 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
         SchedulingSettings $scheduling_settings,
         $context,
         array $data,
-        array $registrations_to_exclude_where_query
+        array $registrations_to_exclude
     ) {
         if (! $scheduling_settings->getMessageTemplateGroup()->is_global()) {
             return array();
         }
-
-        // extract the ids of registrations already in the data array.
-        $additional_where_conditions = array();
-        $registration_ids = isset($data[ $context ])
-            ? array_keys($data[ $context ])
-            : array();
-        if ($registration_ids) {
-            $additional_where_conditions['REG_ID'] = array('NOT_IN', $registration_ids);
-        }
-        $additional_where_conditions = array_merge(
-            $additional_where_conditions,
-            $registrations_to_exclude_where_query
-        );
         $registrations = $this->getRegistrationsForMessageTemplateGroup(
             $scheduling_settings,
             $context,
-            $additional_where_conditions
+            $registrations_to_exclude
         );
         return $registrations ? $registrations : array();
     }
@@ -274,19 +269,14 @@ class UpcomingEventNotificationsCommandHandler extends UpcomingNotificationsComm
      *                        array('EVT_ID' => array( 'NOT IN', array(1,2,3))
      * @throws EE_Error
      */
-    protected function registrationsToExcludeWhereQueryConditions($context)
+    protected function registrationsToExclude($context)
     {
         $meta_key = $this->getNotificationMetaKeyForContext($context);
         $where = array(
             'Datetime.DTT_EVT_start' => array('>', time()),
             'Extra_Meta.EXM_key'     => $meta_key,
         );
-        $event_ids_notified = $this->event_model->get_col(array($where));
-        return $event_ids_notified
-            ? array(
-                'EVT_ID*already_notified' => array('NOT IN', $event_ids_notified),
-            )
-            : array();
+        return (array)$this->event_model->get_col(array($where));
     }
 
 

--- a/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
@@ -410,7 +410,7 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
      * The purpose for this method is to get the list of registrations that have already been notified.
      *
      * @param string $context The context we're getting the notified registrations for.
-     * @return array  of registration IDs
+     * @return array  of IDs for the primary model associated with this handler (eg events or datetimes)
      */
     abstract protected function itemsToExclude($context);
 

--- a/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
@@ -125,7 +125,7 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
         $data = array();
         if (! empty($message_template_groups)) {
             $global_group = null;
-            $registrations_to_exclude_where_query = array();
+            $registrations_to_exclude = array();
             /** @var EE_Message_Template_Group $message_template_group */
             foreach ($message_template_groups as $message_template_group) {
                 // if this is a global group then assign to global group property and continue (will be used later)
@@ -139,15 +139,15 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
                     continue;
                 }
                 foreach ($active_contexts as $context) {
-                    $registrations_to_exclude_where_query[ $context ] = isset(
-                        $registrations_to_exclude_where_query[ $context ]
+                    $registrations_to_exclude[ $context ] = isset(
+                        $registrations_to_exclude[ $context ]
                     )
-                        ? $registrations_to_exclude_where_query[ $context ]
-                        : $this->registrationsToExcludeWhereQueryConditions($context);
+                        ? $registrations_to_exclude[ $context ]
+                        : $this->registrationsToExclude($context);
                     $retrieved_data = $this->getDataForCustomMessageTemplateGroup(
                         $settings,
                         $context,
-                        $registrations_to_exclude_where_query[ $context ]
+                        $registrations_to_exclude[ $context ]
                     );
                     $data = $this->combineDataByGroupAndContext(
                         $message_template_group,
@@ -162,16 +162,16 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
                 $active_contexts = $settings->allActiveContexts();
                 if (count($active_contexts) > 0) {
                     foreach ($active_contexts as $context) {
-                        $registrations_to_exclude_where_query[ $context ] = isset(
-                            $registrations_to_exclude_where_query[ $context ]
+                        $registrations_to_exclude[ $context ] = isset(
+                            $registrations_to_exclude[ $context ]
                         )
-                            ? $registrations_to_exclude_where_query[ $context ]
-                            : $this->registrationsToExcludeWhereQueryConditions($context);
+                            ? $registrations_to_exclude[ $context ]
+                            : $this->registrationsToExclude($context);
                         $retrieved_data = $this->getDataForGlobalMessageTemplateGroup(
                             $settings,
                             $context,
                             $data,
-                            $registrations_to_exclude_where_query[ $context ]
+                            $registrations_to_exclude[ $context ]
                         );
                         $data = $this->combineDataByGroupAndContext(
                             $global_group,
@@ -407,14 +407,12 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
 
 
     /**
-     * The purpose for this method is to get the where condition for excluding registrations that have already been
-     * notified.
+     * The purpose for this method is to get the list of registrations that have already been notified.
      *
      * @param string $context The context we're getting the notified registrations for.
-     * @return array  The array should be in the format used for EE model where conditions.  Eg.
-     *                        array('EVT_ID' => array( 'NOT IN', array(1,2,3))
+     * @return array  of registration IDs
      */
-    abstract protected function registrationsToExcludeWhereQueryConditions($context);
+    abstract protected function registrationsToExclude($context);
 
 
     /**
@@ -438,14 +436,14 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
      * @param SchedulingSettings $scheduling_settings This should contain a global EE_Message_Template_Group object.
      * @param string             $context
      * @param array              $data
-     * @param array              $registrations_to_exclude_where_query
+     * @param array              $registrations_to_exclude
      * @return array
      */
     abstract protected function getDataForGlobalMessageTemplateGroup(
         SchedulingSettings $scheduling_settings,
         $context,
         array $data,
-        array $registrations_to_exclude_where_query
+        array $registrations_to_exclude
     );
 
 

--- a/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
+++ b/domain/services/commands/message/UpcomingNotificationsCommandHandler.php
@@ -125,7 +125,7 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
         $data = array();
         if (! empty($message_template_groups)) {
             $global_group = null;
-            $registrations_to_exclude = array();
+            $items_to_exclude = array();
             /** @var EE_Message_Template_Group $message_template_group */
             foreach ($message_template_groups as $message_template_group) {
                 // if this is a global group then assign to global group property and continue (will be used later)
@@ -139,15 +139,15 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
                     continue;
                 }
                 foreach ($active_contexts as $context) {
-                    $registrations_to_exclude[ $context ] = isset(
-                        $registrations_to_exclude[ $context ]
+                    $items_to_exclude[ $context ] = isset(
+                        $items_to_exclude[ $context ]
                     )
-                        ? $registrations_to_exclude[ $context ]
-                        : $this->registrationsToExclude($context);
+                        ? $items_to_exclude[ $context ]
+                        : $this->itemsToExclude($context);
                     $retrieved_data = $this->getDataForCustomMessageTemplateGroup(
                         $settings,
                         $context,
-                        $registrations_to_exclude[ $context ]
+                        $items_to_exclude[ $context ]
                     );
                     $data = $this->combineDataByGroupAndContext(
                         $message_template_group,
@@ -162,16 +162,16 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
                 $active_contexts = $settings->allActiveContexts();
                 if (count($active_contexts) > 0) {
                     foreach ($active_contexts as $context) {
-                        $registrations_to_exclude[ $context ] = isset(
-                            $registrations_to_exclude[ $context ]
+                        $items_to_exclude[ $context ] = isset(
+                            $items_to_exclude[ $context ]
                         )
-                            ? $registrations_to_exclude[ $context ]
-                            : $this->registrationsToExclude($context);
+                            ? $items_to_exclude[ $context ]
+                            : $this->itemsToExclude($context);
                         $retrieved_data = $this->getDataForGlobalMessageTemplateGroup(
                             $settings,
                             $context,
                             $data,
-                            $registrations_to_exclude[ $context ]
+                            $items_to_exclude[ $context ]
                         );
                         $data = $this->combineDataByGroupAndContext(
                             $global_group,
@@ -412,7 +412,7 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
      * @param string $context The context we're getting the notified registrations for.
      * @return array  of registration IDs
      */
-    abstract protected function registrationsToExclude($context);
+    abstract protected function itemsToExclude($context);
 
 
     /**
@@ -420,13 +420,13 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
      *
      * @param SchedulingSettings $scheduling_settings
      * @param string             $context What context this is for.
-     * @param array              $registrations_to_exclude_where_query
+     * @param array              $items_to_exclude
      * @return array
      */
     abstract protected function getDataForCustomMessageTemplateGroup(
         SchedulingSettings $scheduling_settings,
         $context,
-        array $registrations_to_exclude_where_query
+        array $items_to_exclude
     );
 
 
@@ -436,14 +436,14 @@ abstract class UpcomingNotificationsCommandHandler extends CompositeCommandHandl
      * @param SchedulingSettings $scheduling_settings This should contain a global EE_Message_Template_Group object.
      * @param string             $context
      * @param array              $data
-     * @param array              $registrations_to_exclude
+     * @param array              $items_to_exclude
      * @return array
      */
     abstract protected function getDataForGlobalMessageTemplateGroup(
         SchedulingSettings $scheduling_settings,
         $context,
         array $data,
-        array $registrations_to_exclude
+        array $items_to_exclude
     );
 
 

--- a/tests/includes/AddonTestCase.php
+++ b/tests/includes/AddonTestCase.php
@@ -291,6 +291,15 @@ class AddonTestCase extends EE_UnitTestCase
                 unset($datetimes[$dkey]);
                 $dtt_count++;
             }
+            // In order to test properly and reproduce the live environment, it's important that the event
+            // be attached to another message template group.
+            // See https://github.com/eventespresso/eea-automated-upcoming-event-notifications/issues/14#issuecomment-550464526
+            $message_templates = EEM_Message_Template_Group::instance()->get_global_message_template_by_m_and_mt(
+                'email',
+                'payment'
+            );
+            $message_template = reset($message_templates);
+            $event->_add_relation_to($message_template,'Message_Template_Group');
             //save event
             $event->save();
         }

--- a/tests/mocks/UpcomingDatetimeNotificationsCommandHandlerMock.php
+++ b/tests/mocks/UpcomingDatetimeNotificationsCommandHandlerMock.php
@@ -73,4 +73,14 @@ class UpcomingDatetimeNotificationsCommandHandlerMock extends UpcomingDatetimeNo
     {
         return parent::extractGlobalMessageTemplateGroup($message_template_groups);
     }
+
+    /**
+     * Wrappers of the protected function for getting the meta's name
+     * @since $VID:$
+     * @param string $context
+     * @return mixed|string
+     */
+    public function getNotificationMetaKeyForContext($context){
+        return parent::getNotificationMetaKeyForContext($context);
+    }
 }

--- a/tests/testcases/domain/services/commands/UpcomingDatetimeNotificationsCommandHandlerTests.php
+++ b/tests/testcases/domain/services/commands/UpcomingDatetimeNotificationsCommandHandlerTests.php
@@ -113,6 +113,15 @@ class UpcomingDatetimeNotificationsCommandHandlerTests extends AddonTestCase
             $this->assertArrayHasKey('TXN_ID', $registration_record);
             $this->assertEquals($registration_id, $registration_record['REG_ID']);
         }
+
+        //Lastly, check that when we mark the datetime as notified, it doesn't come up again.
+        $expected_datetime->add_extra_meta($this->command_handler_mock->getNotificationMetaKeyForContext('admin'), 'whatever');
+        $data2 = $this->command_handler_mock->getData($this->message_template_groups['datetime']);
+        $datetime_id_and_registration_items = reset($data2);
+        $this->assertTrue(isset($datetime_id_and_registration_items['admin']));
+        $this->assertArrayNotHasKey($expected_datetime->ID(), $datetime_id_and_registration_items['admin']);
+
+
     }
 
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->
Work in progress. There are unit test failures indicating a problem currently.

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes it so event managers don't need to manually update each event in order to trigger automated messages for it. See https://github.com/eventespresso/eea-automated-upcoming-event-notifications/issues/14
It does this by tweaking the SQL used to select for them (specifically, does a condition on a JOIN instead of inside the WHERE conditions)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] See Tony's testing note on https://github.com/eventespresso/eea-automated-upcoming-event-notifications/issues/14#issuecomment-550243004
* [ ] Test the global upcoming event and datetime notifications are sent for new events
* [ ] Test custom upcoming event and datetime notifications are sent for new events


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
