### PR TITLE
Fix post event exclude query

### DIFF
--- a/domain/services/commands/message/PostEventNotificationsCommandHandler.php
+++ b/domain/services/commands/message/PostEventNotificationsCommandHandler.php
@@ -280,7 +280,7 @@ class PostEventNotificationsCommandHandler extends PostNotificationsCommandHandl
     {
         $meta_key = $this->getNotificationMetaKeyForContext($context);
         $where = array(
-            'Datetime.DTT_EVT_end' => array('>', time()),
+            'Datetime.DTT_EVT_end' => array('<', time()),
             'Extra_Meta.EXM_key'     => $meta_key,
         );
         return (array) $this->event_model->get_col(array($where));


### PR DESCRIPTION
See https://eventespresso.com/topic/automated-post-event-notification/

The exclude query is pulling in events with an Event END that is GREATER than now()

It needs to be pulling in event with an event end less than today, as its already in the past! Post-event, doh!